### PR TITLE
Support environment variables for Braintree configuration

### DIFF
--- a/BraintreeASPExample/App_Code/BraintreeConfiguration.cs
+++ b/BraintreeASPExample/App_Code/BraintreeConfiguration.cs
@@ -17,10 +17,22 @@ namespace BraintreeASPExample
         private IBraintreeGateway BraintreeGateway { get; set; }
 
         public IBraintreeGateway CreateGateway() {
-            Environment = GetEnvironment();
-            MerchantId = GetConfigurationSetting("BraintreeMerchantId");
-            PublicKey = GetConfigurationSetting("BraintreePublicKey");
-            PrivateKey = GetConfigurationSetting("BraintreePrivateKey");
+            string environment = System.Environment.GetEnvironmentVariable("BraintreeEnvironment");
+
+            Environment = GetEnvironment(environment);
+            MerchantId = System.Environment.GetEnvironmentVariable("BraintreeMerchantId");
+            PublicKey = System.Environment.GetEnvironmentVariable("BraintreePublicKey");
+            PrivateKey = System.Environment.GetEnvironmentVariable("BraintreePrivateKey");
+
+            if (MerchantId == null || PublicKey == null || PrivateKey == null)
+            {
+                environment = GetConfigurationSetting("BraintreeEnvironment");
+
+                Environment = GetEnvironment(environment);
+                MerchantId = GetConfigurationSetting("BraintreeMerchantId");
+                PublicKey = GetConfigurationSetting("BraintreePublicKey");
+                PrivateKey = GetConfigurationSetting("BraintreePrivateKey");
+            }
 
             return new BraintreeGateway
             {
@@ -36,9 +48,8 @@ namespace BraintreeASPExample
             return ConfigurationManager.AppSettings[setting];
         }
 
-        public Braintree.Environment GetEnvironment()
+        public Braintree.Environment GetEnvironment(string environment)
         {
-            string environment = GetConfigurationSetting("BraintreeEnvironment");
             return environment == "production" ? Braintree.Environment.PRODUCTION : Braintree.Environment.SANDBOX;
         }
 

--- a/BraintreeASPExample/App_Code/IBraintreeConfiguration.cs
+++ b/BraintreeASPExample/App_Code/IBraintreeConfiguration.cs
@@ -11,7 +11,7 @@ namespace BraintreeASPExample
     {
         IBraintreeGateway CreateGateway();
         string GetConfigurationSetting(string setting);
-        Braintree.Environment GetEnvironment();
+        Braintree.Environment GetEnvironment(string environment);
         IBraintreeGateway GetGateway();
     }
 }

--- a/BraintreeASPExampleTests/BraintreeASPExampleTests.csproj
+++ b/BraintreeASPExampleTests/BraintreeASPExampleTests.csproj
@@ -68,6 +68,7 @@
   <ItemGroup>
     <Compile Include="integration\CheckoutsControllerIntegrationTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestHelper.cs" />
     <Compile Include="unit\BraintreeConfigurationTest.cs" />
     <Compile Include="unit\CheckoutsControllerTest.cs" />
   </ItemGroup>

--- a/BraintreeASPExampleTests/TestHelper.cs
+++ b/BraintreeASPExampleTests/TestHelper.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace BraintreeASPExampleTests
+{
+    public class TestHelper
+    {
+        public const string BRAINTREE_ENVIRONMENT = "BraintreeEnvironment";
+        public const string BRAINTREE_MERCHANT_ID = "BraintreeMerchantId";
+        public const string BRAINTREE_PUBLIC_KEY = "BraintreePublicKey";
+        public const string BRAINTREE_PRIVATE_KEY = "BraintreePrivateKey";
+
+        string environment;
+        string merchantId;
+        string publicKey;
+        string privateKey;
+
+        public void StoreEnvironmentVariables()
+        {
+            environment = System.Environment.GetEnvironmentVariable(BRAINTREE_ENVIRONMENT);
+            merchantId = System.Environment.GetEnvironmentVariable(BRAINTREE_MERCHANT_ID);
+            publicKey = System.Environment.GetEnvironmentVariable(BRAINTREE_PUBLIC_KEY);
+            privateKey = System.Environment.GetEnvironmentVariable(BRAINTREE_PRIVATE_KEY);
+        }
+
+        public void RemoveEnvironmentVariables()
+        {
+            System.Environment.SetEnvironmentVariable(BRAINTREE_ENVIRONMENT, null, EnvironmentVariableTarget.Process);
+            System.Environment.SetEnvironmentVariable(BRAINTREE_MERCHANT_ID, null, EnvironmentVariableTarget.Process);
+            System.Environment.SetEnvironmentVariable(BRAINTREE_PUBLIC_KEY, null, EnvironmentVariableTarget.Process);
+            System.Environment.SetEnvironmentVariable(BRAINTREE_PRIVATE_KEY, null, EnvironmentVariableTarget.Process);
+        }
+
+        public void RestoreEnvironmentVariables()
+        {
+            System.Environment.SetEnvironmentVariable(BRAINTREE_ENVIRONMENT, environment, EnvironmentVariableTarget.Process);
+            System.Environment.SetEnvironmentVariable(BRAINTREE_MERCHANT_ID, merchantId, EnvironmentVariableTarget.Process);
+            System.Environment.SetEnvironmentVariable(BRAINTREE_PUBLIC_KEY, publicKey, EnvironmentVariableTarget.Process);
+            System.Environment.SetEnvironmentVariable(BRAINTREE_PRIVATE_KEY, privateKey, EnvironmentVariableTarget.Process);
+        }
+    }
+}

--- a/BraintreeASPExampleTests/unit/BraintreeConfigurationTest.cs
+++ b/BraintreeASPExampleTests/unit/BraintreeConfigurationTest.cs
@@ -8,16 +8,51 @@ namespace BraintreeASPExampleTests
     [TestClass]
     public class BraintreeConfigurationTest
     {
+        private TestHelper testHelper;
+
+        [TestInitialize]
+        public void CaptureEnvironmentVariables()
+        {
+            testHelper = new TestHelper();
+            testHelper.StoreEnvironmentVariables();
+        }
+
         [TestMethod]
         public void TestConfiguringGateway()
         {
-            BraintreeConfiguration config = new BraintreeConfiguration();
+            testHelper.RemoveEnvironmentVariables();
+
+            IBraintreeConfiguration config = new BraintreeConfiguration();
             var gateway = config.GetGateway();
 
             Assert.AreEqual(gateway.Environment, Braintree.Environment.SANDBOX);
             Assert.AreEqual(gateway.MerchantId, "MerchantId");
             Assert.AreEqual(gateway.PublicKey, "PublicKey");
             Assert.AreEqual(gateway.PrivateKey, "PrivateKey");
+        }
+
+        [TestMethod]
+        public void TestEnvironmentVariableGateway()
+        {
+            IBraintreeConfiguration config = new BraintreeConfiguration();
+
+            System.Environment.SetEnvironmentVariable(TestHelper.BRAINTREE_ENVIRONMENT, "sandbox", EnvironmentVariableTarget.Process);
+            System.Environment.SetEnvironmentVariable(TestHelper.BRAINTREE_MERCHANT_ID, "TestEnvMerchantId", EnvironmentVariableTarget.Process);
+            System.Environment.SetEnvironmentVariable(TestHelper.BRAINTREE_PUBLIC_KEY, "TestEnvPublicKey", EnvironmentVariableTarget.Process);
+            System.Environment.SetEnvironmentVariable(TestHelper.BRAINTREE_PRIVATE_KEY, "TestEnvPrivateKey", EnvironmentVariableTarget.Process);
+
+            var gateway = config.GetGateway();
+
+            Assert.AreEqual(gateway.Environment, Braintree.Environment.SANDBOX);
+            Assert.AreEqual(gateway.MerchantId, "TestEnvMerchantId");
+            Assert.AreEqual(gateway.PublicKey, "TestEnvPublicKey");
+            Assert.AreEqual(gateway.PrivateKey, "TestEnvPrivateKey");
+        }
+
+        [TestCleanup]
+        public void CleanUpEnvironmentVariables()
+        {
+            testHelper.RestoreEnvironmentVariables();
         }
     }
 }


### PR DESCRIPTION
The other Braintree examples allow environmental variables to be used to configure the connection to Braintree. This PR extends this support and defaults to using environment variables if all of the critical credentials are available.

It is important to note that although this extends support to environment variables, it is still recommended to alter the credential values in the `Web.config` file.