### PR TITLE
Update braintree configuration to use string environment

### DIFF
--- a/BraintreeASPExample/App_Code/BraintreeConfiguration.cs
+++ b/BraintreeASPExample/App_Code/BraintreeConfiguration.cs
@@ -10,47 +10,33 @@ namespace BraintreeASPExample
 {
     public class BraintreeConfiguration : IBraintreeConfiguration
     {
-        public Braintree.Environment Environment { get; set; }
+        public string Environment { get; set; }
         public string MerchantId { get; set; }
         public string PublicKey { get; set; }
         public string PrivateKey { get; set; }
         private IBraintreeGateway BraintreeGateway { get; set; }
 
-        public IBraintreeGateway CreateGateway() {
-            string environment = System.Environment.GetEnvironmentVariable("BraintreeEnvironment");
-
-            Environment = GetEnvironment(environment);
+        public IBraintreeGateway CreateGateway()
+        {
+            Environment = System.Environment.GetEnvironmentVariable("BraintreeEnvironment");
             MerchantId = System.Environment.GetEnvironmentVariable("BraintreeMerchantId");
             PublicKey = System.Environment.GetEnvironmentVariable("BraintreePublicKey");
             PrivateKey = System.Environment.GetEnvironmentVariable("BraintreePrivateKey");
 
             if (MerchantId == null || PublicKey == null || PrivateKey == null)
             {
-                environment = GetConfigurationSetting("BraintreeEnvironment");
-
-                Environment = GetEnvironment(environment);
+                Environment = GetConfigurationSetting("BraintreeEnvironment");
                 MerchantId = GetConfigurationSetting("BraintreeMerchantId");
                 PublicKey = GetConfigurationSetting("BraintreePublicKey");
                 PrivateKey = GetConfigurationSetting("BraintreePrivateKey");
             }
 
-            return new BraintreeGateway
-            {
-                Environment = Environment,
-                MerchantId = MerchantId,
-                PublicKey = PublicKey,
-                PrivateKey = PrivateKey
-            };
+            return new BraintreeGateway(Environment, MerchantId, PublicKey, PrivateKey);
         }
 
         public string GetConfigurationSetting(string setting)
         {
             return ConfigurationManager.AppSettings[setting];
-        }
-
-        public Braintree.Environment GetEnvironment(string environment)
-        {
-            return environment == "production" ? Braintree.Environment.PRODUCTION : Braintree.Environment.SANDBOX;
         }
 
         public IBraintreeGateway GetGateway()

--- a/BraintreeASPExample/App_Code/IBraintreeConfiguration.cs
+++ b/BraintreeASPExample/App_Code/IBraintreeConfiguration.cs
@@ -11,7 +11,6 @@ namespace BraintreeASPExample
     {
         IBraintreeGateway CreateGateway();
         string GetConfigurationSetting(string setting);
-        Braintree.Environment GetEnvironment(string environment);
         IBraintreeGateway GetGateway();
     }
 }

--- a/BraintreeASPExample/BraintreeASPExample.csproj
+++ b/BraintreeASPExample/BraintreeASPExample.csproj
@@ -22,6 +22,7 @@
     <IISExpressUseClassicPipelineMode />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,8 +42,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Braintree-2.53.0">
-      <HintPath>..\packages\Braintree.2.53.0\lib\Braintree-2.53.0.dll</HintPath>
+    <Reference Include="Braintree-2.59.0">
+      <HintPath>..\packages\Braintree.2.59.0\lib\Braintree-2.59.0.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/BraintreeASPExample/packages.config
+++ b/BraintreeASPExample/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Braintree" version="2.53.0" targetFramework="net45" />
+  <package id="Braintree" version="2.59.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />

--- a/BraintreeASPExampleTests/BraintreeASPExampleTests.csproj
+++ b/BraintreeASPExampleTests/BraintreeASPExampleTests.csproj
@@ -37,8 +37,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Braintree-2.53.0">
-      <HintPath>..\packages\Braintree.2.53.0\lib\Braintree-2.53.0.dll</HintPath>
+    <Reference Include="Braintree-2.59.0, Version=2.59.0.0, Culture=neutral, PublicKeyToken=31b586f34d3e96c7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Braintree.2.59.0\lib\Braintree-2.59.0.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/BraintreeASPExampleTests/packages.config
+++ b/BraintreeASPExampleTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Braintree" version="2.53.0" targetFramework="net45" />
+  <package id="Braintree" version="2.59.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="Selenium.WebDriver" version="2.52.0" targetFramework="net45" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There are unit and integration tests. To run the integration tests, you will nee
 ## Pro Tips
 
  * If you do not want to or are unable to use NuGet package restore, make sure to download and reference the following packages:
-   * [Braintree](https://developers.braintreepayments.com/start/hello-server/dotnet#install-and-configure) 2.53.0 or higher
+   * [Braintree](https://developers.braintreepayments.com/start/hello-server/dotnet#install-and-configure) 2.59.0 or higher
    * [Moq](https://github.com/Moq/moq4) 4.2 or higher (needed for `BraintreeASPExampleTests` only)
    * [Selenium WebDriver](https://www.seleniumhq.org/download) 2.52 or higher (needed for `BraintreeASPExampleTests` only)
 


### PR DESCRIPTION
This PR updates this example to use a string environment for configuration instead of mapping from a string to a `Braintree.Environment` enum